### PR TITLE
Add URL to outputs when updating API Gateway

### DIFF
--- a/registry/aws-apigateway/index.js
+++ b/registry/aws-apigateway/index.js
@@ -1,6 +1,6 @@
 const AWS = require('aws-sdk')
 const { equals } = require('ramda')
-const { getSwaggerDefinition, generateUrls } = require('./utils')
+const { getSwaggerDefinition, generateUrl, generateUrls } = require('./utils')
 
 const APIGateway = new AWS.APIGateway({ region: 'us-east-1' }) // TODO: make configurable
 
@@ -30,11 +30,12 @@ const createApi = async (params) => {
 
   await APIGateway.createDeployment({ restApiId: res.id, stageName: 'dev' }).promise()
 
+  const url = generateUrl(res.id)
   const urls = generateUrls(routes, res.id)
 
   const outputs = {
     id: res.id,
-    url: `https://${res.id}.execute-api.us-east-1.amazonaws.com/dev/`,
+    url,
     urls
   }
   return outputs
@@ -55,10 +56,12 @@ const updateApi = async (params) => {
 
   await APIGateway.createDeployment({ restApiId: id, stageName: 'dev' }).promise()
 
+  const url = generateUrl(id)
   const urls = generateUrls(routes, id)
 
   const outputs = {
     id,
+    url,
     urls
   }
   return outputs

--- a/registry/aws-apigateway/utils.js
+++ b/registry/aws-apigateway/utils.js
@@ -179,16 +179,20 @@ function getSwaggerDefinition(name, roleArn, routes) {
   return definition
 }
 
+function generateUrl(id, region = 'us-east-1', stage = 'dev') {
+  return `https://${id}.execute-api.${region}.amazonaws.com/${stage}`
+}
+
 function generateUrls(routes, restApiId) {
   const paths = keys(routes)
-  return map(
-    (path) =>
-      `https://${restApiId}.execute-api.us-east-1.amazonaws.com/dev/${path.replace(/^\/+/, '')}`,
-    paths
-  )
+  return map((path) => {
+    const baseUrl = generateUrl(restApiId)
+    return `${baseUrl}/${path.replace(/^\/+/, '')}`
+  }, paths)
 }
 
 module.exports = {
   getSwaggerDefinition,
+  generateUrl,
   generateUrls
 }

--- a/registry/aws-apigateway/utils.test.js
+++ b/registry/aws-apigateway/utils.test.js
@@ -1,0 +1,49 @@
+const { generateUrl, generateUrls } = require('./utils')
+
+describe('Component aws-apigateway - Utils', () => {
+  describe('#generateUrl()', () => {
+    const restApiId = 'r35t4p11d'
+
+    it('should generate the API Gateway base url', () => {
+      const res = generateUrl(restApiId)
+      expect(res).toEqual(`https://${restApiId}.execute-api.us-east-1.amazonaws.com/dev`)
+    })
+
+    it('should be possible to set the region', () => {
+      const region = 'eu-central-1'
+      const res = generateUrl(restApiId, region)
+      expect(res).toEqual(`https://${restApiId}.execute-api.${region}.amazonaws.com/dev`)
+    })
+
+    it('should be possible to set the stage', () => {
+      const region = 'eu-west-1'
+      const stage = 'prod'
+      const res = generateUrl(restApiId, region, stage)
+      expect(res).toEqual(`https://${restApiId}.execute-api.${region}.amazonaws.com/${stage}`)
+    })
+  })
+
+  describe('#generateUrls()', () => {
+    const restApiId = 'r35t4p11d'
+    const routes = {
+      foo: {
+        GET: {
+          function: 'foo-function'
+        }
+      },
+      '/bar': {
+        post: {
+          function: 'bar-function'
+        }
+      }
+    }
+
+    it('should generate the distinct URLs for the given paths', () => {
+      const res = generateUrls(routes, restApiId)
+      expect(res).toEqual([
+        `https://${restApiId}.execute-api.us-east-1.amazonaws.com/dev/foo`,
+        `https://${restApiId}.execute-api.us-east-1.amazonaws.com/dev/bar`
+      ])
+    })
+  })
+})


### PR DESCRIPTION
## What has been implemented?

Fixes a state issue where the url disappeared fromt he state when the `rest-api` routes were updating after a successfull deploy.

## Steps to verify

Use this service:

```yml
type: my-project

components:
  myFunction:
    type: aws-lambda
    inputs:
      memory: 512
      timeout: 10
      handler: handler.handler
      role:
        arn: ${myRole.arn}
  myRole:
    type: aws-iam-role
    inputs:
      service: lambda.amazonaws.com
  myRestApi:
    type: rest-api
    inputs:
      gateway: aws-apigateway
      routes:
        /foo:
          get:
            function: ${myFunction}
            cors: true
        # /bar:
        #   post:
        #     function: ${myFunction}
        #     cors: true
```

1. Run `components deploy`
1. Inspect the `state.json` file content and see that the base url is saved at the `url` property
1. Uncomment the `/bar` route definition
1. Run `components deploy`
1. Inspect the `state.json` file content and see that the base url is still saved at the `url` property

## Todos:

* [x] Write tests
* [x] Run Prettier