### PR TITLE
Remove name properties from basic example to avoid name collisions

### DIFF
--- a/examples/basic/serverless.yml
+++ b/examples/basic/serverless.yml
@@ -4,7 +4,6 @@ components:
   myFunction:
     type: aws-lambda
     inputs:
-      name: some-function
       memory: 512
       timeout: 10
       handler: handler.handler
@@ -13,5 +12,4 @@ components:
   myRole:
     type: aws-iam-role
     inputs:
-      name: some-role
       service: lambda.amazonaws.com


### PR DESCRIPTION
## What has been implemented?

Removes the set names to avoid name collisions when deploying the service from scratch and other resources deployed to AWS already use this name.

## Steps to verify

1. `cd` into `examples/basic`
1. Run `components deploy`

## Todos:

* [x] Run Prettier