### PR TITLE
Remove unnecessary suffix for auto-generated aws-lambda role

### DIFF
--- a/registry/aws-lambda/index.js
+++ b/registry/aws-lambda/index.js
@@ -82,7 +82,7 @@ const deploy = async (inputs, context) => {
   let { defaultRole } = context.state
 
   const defaultRoleComponent = await context.load('aws-iam-role', 'defaultRole', {
-    name: `${inputs.name}-execution-role-${context.instanceId}`,
+    name: `${inputs.name}-execution-role`,
     service: 'lambda.amazonaws.com'
   })
 


### PR DESCRIPTION
## What has been implemented?

Removes the unnecessary role suffix which makes the name longer as it needs to be (and therefore might introduce resource name validation errors in the future).

@brianneisler discovered it in https://github.com/serverless/serverless-components/pull/89#pullrequestreview-107124426

## Steps to verify

```yml
type: my-project

components:
  myFunction:
    type: aws-lambda
    inputs:
      memory: 512
      timeout: 10
      handler: handler.handler
```

1. Run `components deploy`
1. See that the role name is already suffixed with the function name (which is unique in our case)
1. Run `components remove`

## Todos:

* [x] Run Prettier