### PR TITLE
Refactor aws-lambda zipping functionality

### DIFF
--- a/registry/aws-lambda/index.js
+++ b/registry/aws-lambda/index.js
@@ -1,3 +1,4 @@
+const os = require('os')
 const AWS = require('aws-sdk')
 const pack = require('./pack')
 
@@ -6,7 +7,7 @@ const lambda = new AWS.Lambda({ region: 'us-east-1' })
 const createLambda = async ({
   name, handler, memory, timeout, env, description
 }, role) => {
-  const pkg = await pack()
+  const pkg = await pack(os.tmpdir())
 
   const params = {
     FunctionName: name,
@@ -35,7 +36,7 @@ const createLambda = async ({
 const updateLambda = async ({
   name, handler, memory, timeout, env, description
 }, role) => {
-  const pkg = await pack()
+  const pkg = await pack(os.tmpdir())
   const functionCodeParams = {
     FunctionName: name,
     ZipFile: pkg,

--- a/registry/aws-lambda/pack.test.js
+++ b/registry/aws-lambda/pack.test.js
@@ -1,0 +1,56 @@
+const path = require('path')
+const os = require('os')
+const crypto = require('crypto')
+const fse = require('fs-extra')
+const BbPromise = require('bluebird')
+const admZip = require('adm-zip')
+const pack = require('./pack')
+
+const fsp = BbPromise.promisifyAll(fse)
+
+describe('#pack()', () => {
+  let tmpDirPath
+  let oldCwd
+
+  beforeEach(async () => {
+    tmpDirPath = path.join(
+      os.tmpdir(),
+      'tmpdirs-serverless-components',
+      'aws-lambda',
+      crypto.randomBytes(8).toString('hex')
+    )
+    await fsp.ensureDirAsync(tmpDirPath)
+    oldCwd = process.cwd()
+    process.chdir(tmpDirPath)
+  })
+
+  afterEach(() => {
+    process.chdir(oldCwd)
+  })
+
+  it('should zip the cwd and return the zip file content', async () => {
+    const jsonFileSourcePath = path.join(tmpDirPath, 'foo.json')
+    fsp.writeJsonAsync(jsonFileSourcePath, {
+      key1: 'value1',
+      key2: 'value2'
+    })
+
+    const zipRes = await pack(tmpDirPath)
+
+    const zip = admZip(zipRes)
+    const files = zip.getEntries().map((entry) => ({
+      name: entry.entryName,
+      content: entry.getData()
+    }))
+
+    const zipFile = files.filter((file) => file.name.match(/.+.zip/)).pop()
+    const jsonFile = files.filter((file) => file.name === 'foo.json').pop()
+
+    expect(files.length).toEqual(2)
+    expect(zipFile).not.toBeFalsy()
+    expect(JSON.parse(jsonFile.content.toString('utf8'))).toEqual({
+      key1: 'value1',
+      key2: 'value2'
+    })
+  })
+})

--- a/registry/aws-lambda/package-lock.json
+++ b/registry/aws-lambda/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "adm-zip": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
+      "integrity": "sha1-hgbCy/HEJs6MjsABdER/1Jtur8E=",
+      "dev": true
+    },
     "archiver": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
@@ -73,6 +79,11 @@
       "requires": {
         "readable-stream": "2.3.4"
       }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -146,6 +157,17 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.1"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -197,6 +219,15 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "lazystream": {
       "version": "1.0.0",
@@ -302,6 +333,12 @@
         "readable-stream": "2.3.4",
         "xtend": "4.0.1"
       }
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "dev": true
     },
     "url": {
       "version": "0.10.3",

--- a/registry/aws-lambda/package.json
+++ b/registry/aws-lambda/package.json
@@ -13,7 +13,12 @@
   "author": "serverless.com",
   "license": "Apache-2.0",
   "dependencies": {
+    "archiver": "^2.1.1",
     "aws-sdk": "^2.201.0",
-    "archiver": "^2.1.1"
+    "bluebird": "^3.5.1"
+  },
+  "devDependencies": {
+    "adm-zip": "^0.4.7",
+    "fs-extra": "^5.0.0"
   }
 }


### PR DESCRIPTION
## What has been implemented?

Refactor the way we zip to use async only code and waiting for the writeStream to be opened before piping data into it.

## Steps to verify

`deploy`, `invoke`, re-`deploy` and re-`invoke` the following service:

```yml
type: my-project

components:
  myFunction:
    type: aws-lambda
    inputs:
      memory: 512
      timeout: 10
      handler: handler.handler
      role:
        arn: ${myRole.arn}
  myRole:
    type: aws-iam-role
    inputs:
      service: lambda.amazonaws.com
```

## Todos:

* [x] Write tests
* [x] Run Prettier