### PR TITLE
Add trailing slash to generated URLs

### DIFF
--- a/registry/aws-apigateway/utils.js
+++ b/registry/aws-apigateway/utils.js
@@ -180,14 +180,14 @@ function getSwaggerDefinition(name, roleArn, routes) {
 }
 
 function generateUrl(id, region = 'us-east-1', stage = 'dev') {
-  return `https://${id}.execute-api.${region}.amazonaws.com/${stage}`
+  return `https://${id}.execute-api.${region}.amazonaws.com/${stage}/`
 }
 
 function generateUrls(routes, restApiId) {
   const paths = keys(routes)
   return map((path) => {
     const baseUrl = generateUrl(restApiId)
-    return `${baseUrl}/${path.replace(/^\/+/, '')}`
+    return `${baseUrl}${path.replace(/^\/+/, '')}`
   }, paths)
 }
 

--- a/registry/aws-apigateway/utils.test.js
+++ b/registry/aws-apigateway/utils.test.js
@@ -6,20 +6,25 @@ describe('Component aws-apigateway - Utils', () => {
 
     it('should generate the API Gateway base url', () => {
       const res = generateUrl(restApiId)
-      expect(res).toEqual(`https://${restApiId}.execute-api.us-east-1.amazonaws.com/dev`)
+      expect(res).toEqual(`https://${restApiId}.execute-api.us-east-1.amazonaws.com/dev/`)
     })
 
     it('should be possible to set the region', () => {
       const region = 'eu-central-1'
       const res = generateUrl(restApiId, region)
-      expect(res).toEqual(`https://${restApiId}.execute-api.${region}.amazonaws.com/dev`)
+      expect(res).toEqual(`https://${restApiId}.execute-api.${region}.amazonaws.com/dev/`)
     })
 
     it('should be possible to set the stage', () => {
       const region = 'eu-west-1'
       const stage = 'prod'
       const res = generateUrl(restApiId, region, stage)
-      expect(res).toEqual(`https://${restApiId}.execute-api.${region}.amazonaws.com/${stage}`)
+      expect(res).toEqual(`https://${restApiId}.execute-api.${region}.amazonaws.com/${stage}/`)
+    })
+
+    it('should append a slash at the end of the generated url', () => {
+      const res = generateUrl(restApiId)
+      expect(res).toMatch(/^.+\/$/)
     })
   })
 


### PR DESCRIPTION
## What has been implemented?

Adds a trailing slash to the generated URLs (as reported by @ac360).

## Steps to verify

Deploy the `retail-app` example and see that the broken URLs are working fine again.

## Todos:

* [x] Write tests
* [x] Run Prettier