### PR TITLE
Remove misleading DynamoDB table log statement

### DIFF
--- a/registry/aws-dynamodb/index.js
+++ b/registry/aws-dynamodb/index.js
@@ -237,7 +237,6 @@ const deploy = async (inputs, context) => {
       context.log('Cannot deploy multiple tables at this time. Please update your inputs and try again...')
       return {}
     }
-    context.log('Creating table(s)...')
     try {
       outputs = await createTables(inputs, context)
     } catch (err) {


### PR DESCRIPTION
## What has been implemented?

Removes a misleading DDB log statement that tables(s) are created.

## Steps to verify

Deploy the `retail-app` example and follow the logs. For each table you should see separate log messages that they table is created. The overall message which says that table(s) are being created shouldn't be visible anymore.

## Todos:

* [x] Run Prettier