### PR TITLE
Skip empty state removals

### DIFF
--- a/src/utils/components/executeComponent.js
+++ b/src/utils/components/executeComponent.js
@@ -13,7 +13,6 @@ const executeComponent = async (
   rollback = false
 ) => {
   const component = components[componentId]
-  const context = generateContext(components, component, stateFile, archive, options, command)
   component.inputs = resolvePostExecutionVars(component.inputs, components)
 
   if (rollback) {
@@ -21,6 +20,11 @@ const executeComponent = async (
     stateFile[componentId] = archive[componentId]
   } else if (command === 'remove') {
     component.inputs = getInputs(stateFile, componentId)
+  }
+
+  const context = generateContext(components, component, stateFile, archive, options, command)
+
+  if (command === 'remove') {
     if (isEmpty(context.state)) {
       return component
     }

--- a/src/utils/components/executeComponent.test.js
+++ b/src/utils/components/executeComponent.test.js
@@ -1,3 +1,4 @@
+const { assocPath } = require('ramda')
 const executeComponent = require('./executeComponent')
 
 describe('#executeComponent()', () => {
@@ -136,22 +137,45 @@ describe('#executeComponent()', () => {
     expect(res.outputs).toEqual({ result: 'rolled back' })
   })
 
-  it('should treat removals differently', async () => {
+  describe('when running "remove"', () => {
     const command = 'remove'
-    const res = await executeComponent(
-      componentId,
-      components,
-      stateFile,
-      archive,
-      command,
-      options
-    )
-    expect(res.executed).toEqual(true)
-    expect(res.inputs).toEqual({
-      name: 'state-inputs-function-name',
-      memorySize: 128,
-      timeout: 5
+
+    it('should treat removals differently', async () => {
+      const res = await executeComponent(
+        componentId,
+        components,
+        stateFile,
+        archive,
+        command,
+        options
+      )
+      expect(res.executed).toEqual(true)
+      expect(res.inputs).toEqual({
+        name: 'state-inputs-function-name',
+        memorySize: 128,
+        timeout: 5
+      })
+      expect(res.outputs).toEqual({ result: 'removed' })
     })
-    expect(res.outputs).toEqual({ result: 'removed' })
+
+    it('should skip the command if the state is an empty object', async () => {
+      stateFile = assocPath([ 'myFunction', 'state' ], {}, stateFile)
+
+      const res = await executeComponent(
+        componentId,
+        components,
+        stateFile,
+        archive,
+        command,
+        options
+      )
+      expect(res.executed).toBeFalsy()
+      expect(res.inputs).toEqual({
+        name: 'state-inputs-function-name',
+        memorySize: 128,
+        timeout: 5
+      })
+      expect(res.outputs).toEqual({})
+    })
   })
 })


### PR DESCRIPTION
## What has been implemented?

Skips removals based on empty states which caused the framework to error-out in the past.

## Steps to verify

Deploy the `basic` example app. Remove it and run `remove` again.

## Todos:

* [x] Write tests
* [x] Run Prettier