### PR TITLE
Throw error when detecting non-installed dependencies

### DIFF
--- a/src/utils/components/requireFns.js
+++ b/src/utils/components/requireFns.js
@@ -1,8 +1,22 @@
+const path = require('path')
+
 const requireFns = (componentRoot) => {
   let fns = {}
   try {
     fns = require(componentRoot) // eslint-disable-line global-require, import/no-dynamic-require
-  } catch (error) {} // eslint-disable-line no-empty
+  } catch (error) {
+    const moduleName = error.message.split("'")[1]
+    if (moduleName) {
+      const includesPathInfo = new RegExp(path.sep)
+      if (!moduleName.match(includesPathInfo)) {
+        const msg = [
+          `Cannot find module '${moduleName}'.`,
+          'Have you installed all component dependencies?'
+        ].join(' ')
+        throw new Error(msg)
+      }
+    }
+  } // eslint-disable-line no-empty
   return fns
 }
 

--- a/src/utils/components/requireFns.test.js
+++ b/src/utils/components/requireFns.test.js
@@ -1,0 +1,13 @@
+const requireFns = require('./requireFns')
+
+describe('#requireFns()', () => {
+  it('should silently fail if component entry point could not be loaded', () => {
+    const componentRoot = './registry/some-component'
+    expect(() => requireFns(componentRoot)).not.toThrowError()
+  })
+
+  it('should throw a custom error message if a component dependency is not installed', () => {
+    const componentRoot = 'some-dependency'
+    expect(() => requireFns(componentRoot)).toThrowError(/Have you installed/)
+  })
+})


### PR DESCRIPTION
## What has been implemented?

Detect when dependencies are not installed and show an appropriate error message.

## Steps to verify

### `examples/test`

The service used to test this functionality.

```yml
# examples/test/serverless.yml

type: test

components:
  myComponent:
    type: some-component
```

```js
// example/test/index.js

const express = require('express') // NOTE: don't install this

async function deploy(inputs, context) {
  console.log('deploying...')
}

module.exports = {
  deploy
}
```

### `registry/some-component`

Used to validate that entry-point-less services still works.

```
# registry/some-component/serverless.yml

type: some-component

components:
  myTestFunc:
    type: tests-integration-function-mock
    inputs:
      name: some-name
      role: some-role
```

Run `components deploy` in the `example/test` directory. You should see an error message saying that `express` is not installed. You shouldn't see an error message that an `index.js` or other entry-point file for `some-component` is missing.

## Todos:

* [x] Write tests
* [x] Run Prettier