### PR TITLE
Refactor pack tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -696,6 +696,7 @@ Creates / Removes an AWS Lambda function.
 | `timeout`     | The functions timeout                | Number |
 | `description` | The functions description            | String |
 | `handler`     | The functions handler                | String |
+| `root`        | The code root directory              | String |
 | `role`        | The role `arn` the lambda should use | String |
 | `env`         | An object of env vars set at runtime | Object |
 
@@ -718,6 +719,7 @@ components:
       timeout: 10
       description: dome description
       handler: code.handler
+      root: code
       role:
         arn: arn:aws:iam::XXXXX:role/some-lambda-role
 ```

--- a/registry/aws-lambda/pack.test.js
+++ b/registry/aws-lambda/pack.test.js
@@ -13,17 +13,11 @@ describe('#pack()', () => {
   let packagePath
 
   beforeEach(async () => {
-    packagePath = path.join(
-      os.tmpdir(),
-      crypto.randomBytes(6).toString('hex')
-    )
-    tempPath = path.join(
-      os.tmpdir(),
-      crypto.randomBytes(6).toString('hex')
-    )
+    packagePath = path.join(os.tmpdir(), crypto.randomBytes(6).toString('hex'))
+    tempPath = path.join(os.tmpdir(), crypto.randomBytes(6).toString('hex'))
     await fsp.ensureDirAsync(packagePath)
     await fsp.ensureDirAsync(tempPath)
-    fsp.writeJsonSync(path.join(packagePath, 'foo.json'), {
+    await fsp.writeJsonAsync(path.join(packagePath, 'foo.json'), {
       key1: 'value1',
       key2: 'value2'
     })
@@ -38,7 +32,7 @@ describe('#pack()', () => {
     }))
     const jsonFile = files.filter((file) => file.name === 'foo.json').pop()
 
-    expect(files.length === 1)
+    expect(files.length).toEqual(1)
     expect(JSON.parse(jsonFile.content.toString('utf8'))).toEqual({
       key1: 'value1',
       key2: 'value2'


### PR DESCRIPTION
## What has been implemented?

Quick follow-up PR of https://github.com/serverless/serverless-components/pull/115 which ensures async-only code-usage, formatting according to prettier, doc updates and updated assertions.

## Steps to verify

Tests should still pass.

## Todos:

* [x] Write tests
* [x] Run Prettier