### PR TITLE
Remove rollback references in docs

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -26,7 +26,3 @@ To remove the application and delete all dependent resources automatically, simp
 ```
 $ components remove
 ```
-
-### Rollback
-
-If the `deploy` or `remove` commands fail for some reason, the system will automatically `rollback` to the previous _good state_ of the application.

--- a/examples/retail-app/README.md
+++ b/examples/retail-app/README.md
@@ -1,6 +1,6 @@
 ![serverless retail application logo](https://s3.amazonaws.com/assets.github.serverless/serverless-retail-readme-2.png)
 
-An example retail application composed of a few serverless components. The  application has a frontend that displays a catalog of products. The backend relies on a REST API that in turn fetches data from a DynamoDB table. The application is deployable to AWS.
+An example retail application composed of a few serverless components. The application has a frontend that displays a catalog of products. The backend relies on a REST API that in turn fetches data from a DynamoDB table. The application is deployable to AWS.
 
 **[Live Preview Here](https://s3.amazonaws.com/retail-cb2s100ejz.example.com/index.html)**
 
@@ -30,7 +30,3 @@ To remove the application and delete all dependent resources automatically, simp
 ```
 $ components remove
 ```
-
-### Rollback
-
-If the `deploy` or `remove` commands fail for some reason, the system will automatically `rollback` to the previous _good state_ of the application.


### PR DESCRIPTION
## What has been implemented?

Remove the `rollback` support references in the documentation since it's not supported right now.

## Steps to verify

Just glance over the docs.

## Todos:

* [x] Write / update documentation
* [x] Run Prettier