### PR TITLE
Await child state

### DIFF
--- a/src/utils/components/executeComponent.js
+++ b/src/utils/components/executeComponent.js
@@ -1,7 +1,7 @@
 const { is } = require('ramda')
 const generateContext = require('./generateContext')
 const resolvePostExecutionVars = require('../variables/resolvePostExecutionVars')
-const getInputs = require('../state/getInputs')
+const { getInputs, getState } = require('../state')
 
 const executeComponent = async (
   componentId,
@@ -28,6 +28,7 @@ const executeComponent = async (
     component.outputs = (await func(component.inputs, context)) || {}
     component.executed = true
   }
+  component.state = getState(stateFile, component.id)
 
   component.promise.resolve(component)
 

--- a/tests/integration/await-child-components.test.js
+++ b/tests/integration/await-child-components.test.js
@@ -21,7 +21,7 @@ async function removeStateFiles(stateFiles) {
 describe('Integration Test - Await child components', () => {
   jest.setTimeout(20000)
 
-  const testDir = path.dirname(require.main.filename)
+  const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
   const testServiceDir = path.join(testDir, 'await-child-components')
   const testServiceStateFile = path.join(testServiceDir, 'state.json')

--- a/tests/integration/await-child-components.test.js
+++ b/tests/integration/await-child-components.test.js
@@ -59,8 +59,12 @@ describe('Integration Test - Await child components', () => {
       expect(awaitChildComponents).toHaveProperty('instanceId')
       expect(awaitChildComponents).toHaveProperty('type', 'await-child-components')
       expect(awaitChildComponents).toHaveProperty('internallyManaged', false)
-      expect(awaitChildComponents).toHaveProperty('state')
-      expect(awaitChildComponents.state.myFunction).toHaveProperty('outputs', {
+      expect(awaitChildComponents).toHaveProperty(
+        'state.myFunction.state.id',
+        'id:function:my-function'
+      )
+      expect(awaitChildComponents).toHaveProperty('state.myFunction.state.deploymentCounter', 1)
+      expect(awaitChildComponents).toHaveProperty('state.myFunction.outputs', {
         id: 'id:function:my-function',
         name: 'my-function',
         memorySize: 512,

--- a/tests/integration/programmatic-usage.test.js
+++ b/tests/integration/programmatic-usage.test.js
@@ -21,7 +21,7 @@ async function removeStateFiles(stateFiles) {
 describe('Integration Test - Programmatic usage', () => {
   jest.setTimeout(20000)
 
-  const testDir = path.dirname(require.main.filename)
+  const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
   const testServiceDir = path.join(testDir, 'programmatic-usage')
   const testServiceStateFile = path.join(testServiceDir, 'state.json')

--- a/tests/integration/simple.test.js
+++ b/tests/integration/simple.test.js
@@ -21,7 +21,7 @@ async function removeStateFiles(stateFiles) {
 describe('Integration Test - Simple', () => {
   jest.setTimeout(20000)
 
-  const testDir = path.dirname(require.main.filename)
+  const testDir = path.dirname(__filename)
   const componentsExec = path.join(testDir, '..', '..', 'bin', 'components')
   const testServiceDir = path.join(testDir, 'simple')
   const testServiceStateFile = path.join(testServiceDir, 'state.json')


### PR DESCRIPTION
## What has been implemented?

Fixes awaited child components carrying out-of-date state: https://serverlessteam.atlassian.net/browse/SC-197

## Steps to verify

* Cherry-pick https://github.com/serverless/serverless-components/commit/6e94454c938dc1b628b69124a38a71855937d2b1
* Deploy examples/await-state
* See `CHILD STATE: {count:1}` on the very first deploy
