### PR TITLE
Add seed data to products table on deploy

### DIFF
--- a/examples/retail-app/data/products.json
+++ b/examples/retail-app/data/products.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 20,
+    "name": "Model A",
+    "description": "Our standard, highly reliable part.",
+    "price": "6.99"
+  },
+  {
+    "id": 21,
+    "name": "Model B",
+    "description": "A cost-reduced version of our classic offering, providing the highest value.",
+    "price": "4.99"
+  },
+  {
+    "id": 22,
+    "name": "Model A+",
+    "description": "A precision-milled, highly durable enhancement of the Model A for performance applications.",
+    "price": "8.99"
+  }
+]

--- a/examples/retail-app/index.js
+++ b/examples/retail-app/index.js
@@ -1,0 +1,48 @@
+const { readFile } = require('fs')
+
+module.exports = {
+  async deploy(inputs, context) {
+    // TODO: move this functionality into aws-dynamodb component itself
+
+    const productsDb = await context.children.productsDb
+    const products = await new Promise((resolve, reject) =>
+      readFile('data/products.json', (err, data) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(JSON.parse(data))
+        }
+      }))
+
+    if (products.length > 0) {
+      const tablename = `products-${context.serviceId}`
+      context.log(`Seeding ${products.length} items into table ${tablename}.`)
+
+      const insertItem = (triesLeft, wait) => (product) =>
+        productsDb.fns
+          .insert(productsDb.inputs, {
+            log: context.log,
+            state: productsDb.state,
+            options: {
+              tablename,
+              itemdata: product
+            }
+          })
+          .catch(async (error) => {
+            if (triesLeft > 0) {
+              return new Promise((resolve, reject) => {
+                setTimeout(() => {
+                  const doInsert = insertItem(triesLeft - 1, wait)(product)
+                  doInsert.then(resolve, reject)
+                }, wait)
+              })
+            }
+
+            throw error
+          })
+
+      const insertions = products.map(JSON.stringify).map(insertItem(30, 8000))
+      await Promise.all(insertions)
+    }
+  }
+}


### PR DESCRIPTION
## What has been implemented?

Closes https://serverlessteam.atlassian.net/browse/SC-198
On deploy, inserts 3 products into the product DB. The seeding occurs on every deploy, and will overwrite any updates to the items that occurred since deploy, so this can be used to reset or update the default items.

This functionality should eventually be moved into aws-dynamodb.

## Steps to verify

* Deploy retail-app
* Visit the products page; there should be three products named `Model A`, `Model A+`, and `Model B`
